### PR TITLE
BENDFEATS-617 Enhance hmac generator to include a new textbox

### DIFF
--- a/src/components/hamc-builder.js
+++ b/src/components/hamc-builder.js
@@ -68,8 +68,10 @@ function HMACBuilder() {
         }
 
         try {
-            JSON.parse(value);
-            setIsJsonPayloadValid(true);
+            const parsed = JSON.parse(value);
+            const isValidObjectOrArray = typeof parsed === 'object' && parsed !== null;
+
+            setIsJsonPayloadValid(isValidObjectOrArray);
         } catch (e) {
             setIsJsonPayloadValid(false);
         }

--- a/src/components/hamc-builder.js
+++ b/src/components/hamc-builder.js
@@ -222,7 +222,7 @@ function HMACBuilder() {
                                 </Row>
                                 <Form.Group className="mb-3" hidden={httpMethod !== "POST"}>
                                     <Form.Label>Payload</Form.Label>
-                                    <DebounceInput element="textarea" value={payload} className="form-control" minLength={2} debounceTimeout={500} onChange={handlePayloadChange} />
+                                    <DebounceInput element="textarea" value={payload} className="form-control" minLength={2} debounceTimeout={500} onChange={() => {}} onBlur={handlePayloadChange} />
                                      {!isJsonPayloadValid && (<div className="text-danger mt-1">Payload must be valid JSON.</div>)}
                                 </Form.Group>
                                 <Form.Group className="mb-3">

--- a/src/components/hamc-builder.js
+++ b/src/components/hamc-builder.js
@@ -142,12 +142,11 @@ function HMACBuilder() {
 
             let base64Hash = "";
             
-            if(payload.length > 0){
+            if(payload.length > 0) {
                 // Normalize the value in the textbox since in C# it wuold add the \r\n but in textarea its only \n
                 const normalizedPayload = payload.replace(/\n/g, '\r\n');
                 const md5Hash = CryptoJS.MD5(CryptoJS.enc.Utf8.parse(normalizedPayload));
                 base64Hash = CryptoJS.enc.Base64.stringify(md5Hash);
-                
             }
 
             signatureRawData = `${accessKey}${httpMethod}${uri}${base64Hash}${nonce}${timestamp}`;

--- a/src/components/hamc-builder.js
+++ b/src/components/hamc-builder.js
@@ -62,6 +62,11 @@ function HMACBuilder() {
         const value = event.target.value;
         setPayload(value);
 
+        if(value.length == 0 ) {
+            setIsJsonPayloadValid(true);
+            return;
+        }
+
         try {
             JSON.parse(value);
             setIsJsonPayloadValid(true);
@@ -134,11 +139,17 @@ function HMACBuilder() {
         const uri = encode(url);
 
         if (httpMethod == "POST") {
-            // Normalize the value in the textbox since in C# it wuold add the \r\n but in textarea its only \n
-            const normalizedPayload = payload.replace(/\n/g, '\r\n');
 
-            const md5Hash = CryptoJS.MD5(CryptoJS.enc.Utf8.parse(normalizedPayload));
-            const base64Hash = CryptoJS.enc.Base64.stringify(md5Hash);
+            let base64Hash = "";
+            
+            if(payload.length > 0){
+                // Normalize the value in the textbox since in C# it wuold add the \r\n but in textarea its only \n
+                const normalizedPayload = payload.replace(/\n/g, '\r\n');
+                const md5Hash = CryptoJS.MD5(CryptoJS.enc.Utf8.parse(normalizedPayload));
+                base64Hash = CryptoJS.enc.Base64.stringify(md5Hash);
+                
+            }
+
             signatureRawData = `${accessKey}${httpMethod}${uri}${base64Hash}${nonce}${timestamp}`;
         }
         else {


### PR DESCRIPTION
# BENDFEATS-617 Enhance hmac generator to include a new textbox

## Description

This is a followup PR to support POST with no Payload for example.

{{baseUrl}}api/v2/users/:id/validateHMAC

- **What is being changed?**
We had supported the scenario that a POST dont have payload with corresponds to the HMAC logic at the backend 

## Related Issues

- Resolves https://tunedglobal.atlassian.net/browse/BENDFEATS-617

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Hot fix

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have written automated tests to cover the changes
- [ ] I have added the scripts required for this PR
- [X] I have successfully run the tests locally

## Testing

Testing Payload with no BODY
![image](https://github.com/user-attachments/assets/dcac951f-98e3-4124-9400-d2d53d1fa1b6)

Testing Payload non clean Json
![image](https://github.com/user-attachments/assets/0b965123-f558-4505-aabe-0f9b066c7a70)

Testing Clean Json
![image](https://github.com/user-attachments/assets/74c0ef1f-cdc5-4939-b46e-db197af72ffb)


Testing Old GET
![image](https://github.com/user-attachments/assets/1858ba11-d755-4b0c-a038-d24c6f244f9f)



## Deployment

- [] I have confirmed that the deployment steps are added in JIRA
- [X] I have confirmed that the release notes are added in JIRA (if applicable)

## Reviewer Notes

